### PR TITLE
[step 13,14주차 과제 제출합니다] 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,8 +52,10 @@ dependencies {
 	providedRuntime 'jakarta.servlet:jakarta.servlet-api:5.0.0'
 
 	//redis - redission
-
 	implementation 'org.redisson:redisson-spring-boot-starter:3.20.1'
+
+	//caching
+	implementation 'org.springframework.boot:spring-boot-starter-cache'
 
 
 }

--- a/src/main/java/com/hhplus/concert/adapter/interceptor/TokenInterceptor.java
+++ b/src/main/java/com/hhplus/concert/adapter/interceptor/TokenInterceptor.java
@@ -1,7 +1,5 @@
 package com.hhplus.concert.adapter.interceptor;
 
-import com.hhplus.concert.application.usecase.GetTokenStatusUseCase;
-import com.hhplus.concert.application.usecase.GetWaitNoUseCase;
 import com.hhplus.concert.application.usecase.TokenValidationUseCase;
 import com.hhplus.concert.common.constants.MessageEnum;
 import com.hhplus.concert.common.exception.BusinessException;
@@ -10,24 +8,26 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 import org.springframework.web.servlet.ModelAndView;
 
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 @Component
 public class TokenInterceptor implements HandlerInterceptor {
 
     private static final Logger log = LoggerFactory.getLogger(TokenInterceptor.class);
+    private static final long WAIT_TIME_IN_MS = 10*10000;
     @Autowired
-    TokenValidationUseCase tokenValidationUseCase;
-
-    @Autowired
-    GetTokenStatusUseCase getTokenStatusUseCase;
-
-    @Autowired
-    GetWaitNoUseCase getWaitNoUseCase;
+    private RedisTemplate<String, String> redisTemplate;
 
     @Override
     public boolean preHandle(HttpServletRequest request , HttpServletResponse response , Object handler) throws Exception {
@@ -38,39 +38,47 @@ public class TokenInterceptor implements HandlerInterceptor {
             log.warn("[토큰 검증] 헤더에 토큰이 존재하지 않음");
             return false;
         }
-        String userId = validateToken(token);
-        String tokenStatus = getTokenStatus(userId);
-        handleTokenStatus(tokenStatus, userId);
 
-        return true;
+        return handleTokenStatus(token);
     }
 
-    private String validateToken(String token) throws BusinessException {
-        String userId = tokenValidationUseCase.validate(token);
-        if (userId == null) {
-            throw new BusinessException("ERR", MessageEnum.TOKEN_VALIDATION_FAILURE);
+
+    private boolean handleTokenStatus(String token) throws BusinessException {
+
+        ZSetOperations<String, String> zSetOps = redisTemplate.opsForZSet();
+
+        //activeQueue에서 찾기
+        Set<String> tokens = zSetOps.range("activeQueue", 0, -1);
+
+        if(tokens != null && !tokens.isEmpty()) {
+
+
+            for(String tok : tokens) {
+                if(tok.contains(token)) {
+                    log.info("[active토큰입니다]");
+                    return true;
+                }
+            }
         }
-        return userId;
-    }
 
-    private String getTokenStatus(String userId) throws BusinessException {
-        String tokenStatus = getTokenStatusUseCase.getTokenStatus(userId);
-        if (tokenStatus == null) {
-            throw new BusinessException("ERR", MessageEnum.TOKEN_STATUS_FAILURE);
-        }
-        return tokenStatus;
-    }
+        // waitingQueue에서 토큰 찾기
+        Long waitNo = zSetOps.rank("waitingQueue", token);
+        if (waitNo != null) {
 
-    private void handleTokenStatus(String tokenStatus, String userId) throws BusinessException {
-        if ("WAIT".equals(tokenStatus)) {
-            HashMap<String, Long> data = new HashMap<>();
-            data.put("waitNo", getWaitNoUseCase.getWaitNo(userId));
+            // 대기 시간 계산 (3초로 테스트)
+            long totalWaitTimeInMs = (waitNo / 3) * WAIT_TIME_IN_MS;
+            long hours = TimeUnit.SECONDS.toHours(totalWaitTimeInMs);
+            long minutes = TimeUnit.SECONDS.toMinutes(totalWaitTimeInMs) % 60;
+            long seconds = totalWaitTimeInMs % 60;
+            String waitTime = String.format("%02d시간 %02d분 %02d초", hours, minutes, seconds);
+            Map<String, Object> data = Map.of("token", token, "waitNo", waitNo , "waitTime" , waitTime);
+
             throw new BusinessException("OK", MessageEnum.TOKEN_NOW_WAIT_STATUS, data);
         }
 
-        if ("EXPIRED".equals(tokenStatus)) {
-            throw new BusinessException("ERR", MessageEnum.TOKEN_EXPIRED);
-        }
+        throw new BusinessException("ERR" , MessageEnum.TOKEN_EXPIRED);
+
+
     }
 
 

--- a/src/main/java/com/hhplus/concert/adapter/scheduler/QueueScheduler.java
+++ b/src/main/java/com/hhplus/concert/adapter/scheduler/QueueScheduler.java
@@ -1,24 +1,30 @@
 package com.hhplus.concert.adapter.scheduler;
 
+import com.hhplus.concert.application.usecase.CleanUpExpiredTokenUseCase;
 import com.hhplus.concert.application.usecase.QueuePollingUseCase;
 import com.hhplus.concert.domain.service.token.TokenService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+import java.util.Set;
+
 @Component
 public class QueueScheduler {
-
     @Autowired
     QueuePollingUseCase queuePollingUseCase;
 
-    @Scheduled(fixedRate = 3000)
+    @Autowired
+    CleanUpExpiredTokenUseCase cleanUpExpiredTokenUseCase;
+
+    @Scheduled(fixedRate = 10000)
     public void polling() {
-        queuePollingUseCase.checkTokenSchedule();
+        queuePollingUseCase.changeTokenFromWaitingToActive();
     }
 
-    //test
-    //@Scheduled(fixedRate = 1000)
-    //public void makeExpiredPerOneSecond() {queuePollingUseCase.updateActiveToExpiredToken();}
 
+    @Scheduled(fixedRate = 10000)
+    public void cleanUpExpiredTokens() {cleanUpExpiredTokenUseCase.cleanUpExpiredTokens();}
 }

--- a/src/main/java/com/hhplus/concert/application/usecase/CleanUpExpiredTokenUseCase.java
+++ b/src/main/java/com/hhplus/concert/application/usecase/CleanUpExpiredTokenUseCase.java
@@ -1,0 +1,23 @@
+package com.hhplus.concert.application.usecase;
+
+import com.hhplus.concert.domain.service.redis.RedisService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.stereotype.Component;
+
+import java.util.Set;
+
+@Component
+public class CleanUpExpiredTokenUseCase {
+    final static Logger log = LoggerFactory.getLogger(QueuePollingUseCase.class);
+
+    @Autowired
+    RedisService redisService;
+
+    public void cleanUpExpiredTokens() {
+        redisService.cleanUpExpiredTokens();
+    }
+}

--- a/src/main/java/com/hhplus/concert/application/usecase/TokenCreationUseCase.java
+++ b/src/main/java/com/hhplus/concert/application/usecase/TokenCreationUseCase.java
@@ -2,20 +2,23 @@ package com.hhplus.concert.application.usecase;
 
 
 import com.hhplus.concert.application.dto.response.ApiResponse;
-import com.hhplus.concert.application.dto.response.token.TokenCreationResponse;
 import com.hhplus.concert.common.constants.MessageEnum;
-import com.hhplus.concert.domain.model.queue.Queue;
 import com.hhplus.concert.domain.model.token.Token;
 import com.hhplus.concert.domain.model.user.User;
-import com.hhplus.concert.domain.service.queue.QueueService;
 import com.hhplus.concert.domain.service.token.TokenService;
 import com.hhplus.concert.domain.service.user.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.text.SimpleDateFormat;
+import java.time.Instant;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 @Component
 public class TokenCreationUseCase {
@@ -27,7 +30,9 @@ public class TokenCreationUseCase {
     private UserService userService;
 
     @Autowired
-    private QueueService queueService;
+    private RedisTemplate<String, String> redisTemplate;
+
+    private static final long WAIT_TIME_IN_MS = 10 * 1000; //n명당 10초
 
     @Transactional
     public ApiResponse createToken() {
@@ -35,20 +40,24 @@ public class TokenCreationUseCase {
         Token generatedToken = tokenService.createToken();
         String userId = generatedToken.getUserId();
         String token = generatedToken.getToken();
-        String status = generatedToken.getStatus();
-        Date createdAt = generatedToken.getCreatedAt();
+        String key = "waitingQueue";
 
-        //<token to queue>
-        Queue queue = new Queue(userId , token , status , createdAt);
-        User user = new User(userId , token , 0L);
+        userService.insertUser(new User(userId, token, 0L));
 
-        userService.insertUser(user);
-        queueService.insertQueue(queue);
-        long waitNo = queueService.getWaitNo(userId);
+        ZSetOperations<String, String> zSetOps = redisTemplate.opsForZSet();
+        double score = (double) Instant.now().toEpochMilli();
+        zSetOps.add(key, token, score);
+        long waitNo = zSetOps.rank(key , token);
 
-        HashMap<String , Object> data = new HashMap<>();
-        data.put("token" , token);
-        data.put("waitNo" , waitNo);
-        return new ApiResponse("OK" , MessageEnum.TOKEN_CREATEION_SUCCESS , data);
+        // 대기 시간 계산
+        long totalWaitTimeInMs = (waitNo / 3000) * WAIT_TIME_IN_MS;
+        long hours = TimeUnit.SECONDS.toHours(totalWaitTimeInMs);
+        long minutes = TimeUnit.SECONDS.toMinutes(totalWaitTimeInMs) % 60;
+        long seconds = totalWaitTimeInMs % 60;
+        String waitTime = String.format("%02d시간 %02d분 %02d초", hours, minutes, seconds);
+        Map<String, Object> data = Map.of("token", token, "waitNo", waitNo , "waitTime" , waitTime);
+
+        return new ApiResponse("OK", MessageEnum.TOKEN_CREATEION_SUCCESS, data);
+
     }
 }

--- a/src/main/java/com/hhplus/concert/common/config/RedisConfig.java
+++ b/src/main/java/com/hhplus/concert/common/config/RedisConfig.java
@@ -6,17 +6,27 @@ import org.redisson.api.RedissonClient;
 import org.redisson.config.Config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
 
 @RequiredArgsConstructor
 @Configuration
-@EnableRedisRepositories
+@EnableCaching
 public class RedisConfig {
 
     private final RedisProperties redisProperties;
@@ -37,5 +47,23 @@ public class RedisConfig {
         redisson = Redisson.create(config);
         return redisson;
     }
+
+    @Bean
+    public RedisCacheManager  cacheConfiguration(RedisConnectionFactory redisConnectionFactory) {
+
+        RedisCacheConfiguration defaultCacheConfig = RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(Duration.ofMinutes(10))
+                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()));
+
+        Map<String, RedisCacheConfiguration> cacheConfigurations = new HashMap<>();
+        cacheConfigurations.put("Concerts", defaultCacheConfig.entryTtl(Duration.ofMinutes(10)));
+
+        return RedisCacheManager.builder(redisConnectionFactory)
+                .cacheDefaults(defaultCacheConfig)
+                .withInitialCacheConfigurations(cacheConfigurations)
+                .build();  }
+
+
 
 }

--- a/src/main/java/com/hhplus/concert/domain/service/concert/ConcertService.java
+++ b/src/main/java/com/hhplus/concert/domain/service/concert/ConcertService.java
@@ -9,6 +9,7 @@ import com.hhplus.concert.domain.model.concert.ConcertSeat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -53,8 +54,11 @@ public class ConcertService {
         return concertSeatRepository.getPossibleSeats(concertId , concertDy);
     }
 
+    @Cacheable(value="Concerts" , key = "'possibleConcerts'")
     public List<Concert> getPossibleConcerts() {
-        log.info("[예약가능한 콘서트 목록 조회]");
+        log.info("[예약 가능한 콘서트 목록 조회]");
+        List<Concert> concerts = concertRepository.getPossibleConcerts();
+        log.info("Fetched concerts from DB: {}", concerts);
         return concertRepository.getPossibleConcerts();
     }
 

--- a/src/main/java/com/hhplus/concert/domain/service/redis/RedisService.java
+++ b/src/main/java/com/hhplus/concert/domain/service/redis/RedisService.java
@@ -1,0 +1,74 @@
+package com.hhplus.concert.domain.service.redis;
+
+import com.hhplus.concert.adapter.interceptor.TokenInterceptor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.stereotype.Service;
+
+import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import java.util.Set;
+
+
+@Service
+public class RedisService {
+
+    @Autowired
+    RedisTemplate<String , String> redisTemplate;
+    private static final Logger log = LoggerFactory.getLogger(TokenInterceptor.class);
+
+
+    public void changeTokenFromWaitingToActive() {
+
+        log.info("[토큰 waiting -> active 전환 스케줄러 실행] {} ", new Date());
+
+        ZSetOperations<String, String> zSetOps = redisTemplate.opsForZSet();
+        String sourceKey = "waitingQueue";
+        String destinationKey = "activeQueue";
+
+        Set<String> tokens = zSetOps.range(sourceKey, 0, 2999);
+
+        if (tokens != null && !tokens.isEmpty()) {
+            double now = (double) System.currentTimeMillis();
+            String expired = new SimpleDateFormat("yyyyMMddHHmmss").format(new Date());
+
+            for (String token : tokens) {
+                zSetOps.remove(sourceKey, token);
+                zSetOps.add(destinationKey, token+":" +expired , now);
+            }
+        }
+        log.info("[토큰 전환 결과] {} 건의 토큰이 activeQueue로 전환됨", tokens.size());
+    }
+
+
+
+    public void cleanUpExpiredTokens() {
+        ZSetOperations<String, String> zSetOps = redisTemplate.opsForZSet();
+        String destinationKey = "activeQueue";
+        Set<String> tokens = zSetOps.range(destinationKey, 0, -1);
+        if (tokens != null && !tokens.isEmpty()) {
+            for (String token : tokens) {
+                // 만료된 토큰을 제거하기 위해 token:시간 패턴의 키 생성
+
+                String time = token.split(":")[1] ;
+                DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMddHHmmss");
+                LocalDateTime now = LocalDateTime.now();
+                LocalDateTime tenMinutesAgo = now.minus(10, ChronoUnit.MINUTES);
+                LocalDateTime tokenTime = LocalDateTime.parse(time, formatter);
+
+                if(tokenTime.isBefore(tenMinutesAgo)) {
+                    zSetOps.remove(destinationKey, token);
+                    log.info("[active 토큰 시간 만료] : {}", token);
+                }
+            }
+        }
+    }
+
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -27,3 +27,6 @@ spring.redis.port=6379
 logging.level.org.hibernate=INFO
 logging.level.org.springframework.orm.jpa=DEBUG
 logging.level.org.redisson=DEBUG
+
+spring.cache.type=redis
+spring.cache.redis.cache-null-values=true


### PR DESCRIPTION

## Step13. 캐싱 적용 결과서

### 조회성 쿼리 캐싱 적용 판단 기준 & 결과

| 조회 쿼리    | 조회가 자주 발생하는가?                           | 내용이 거의 변경되지 않는가? |  캐시 여부   |  사유 | 
| ------------ | ----------------------------------------------- | ---------------------------| -------- |  ------ | 
| `콘서트 목록 조회`             | O    | O              |      캐싱                           | 두 조건 모두 만족 | 
| `콘서트 예약 가능 일자 조회`   | O    | X               |     캐싱 안함                     | 현재 설계상 연산 이슈가 있음 | 
| `콘서트 예약 가능 좌석 조회`   | O    | X               |     캐싱 안함                            | 내용이 자주 변경되므로 캐싱의 의미가 없음 | 
| `사용자 잔액 조회`             |  X  | O |   캐싱 안함  |     조회가 자주 발생하지 않음             | 


### 콘서트 목록 조회 (캐싱 적용) <br>

**캐시 적용결과** <br> 

![image](https://github.com/user-attachments/assets/74a06990-8a1e-453e-9a59-f5ba04c4e8ca)

![image](https://github.com/user-attachments/assets/d1185e02-887e-4c4f-a263-a7c0b120b98e)

**추후 시도해 볼 방향** :  <br>
현재는 TTL을 10으로 적용, 10분 마다 조회가 된다는 전제로 캐시가 동기화됩니다. <br>
DB 변경시 바로 캐시 변경이 되도록 이벤트 방식을 고려하고자 합니다. <br> 

<br>

### 콘서트 예약 가능 일자 조회 설계 이슈  <br> 

<img src = "https://github.com/user-attachments/assets/4c6f5a96-8f49-4744-ad67-d635ca045093" width="400px" height="300px"/> <br> 

콘서트 예약이 가능한 일자를 조회하기 위해 내부적으로 "좌석의 상태를 조회하는" 연산 쿼리가 발생하고 있습니다.  <br> 
연산 시점의 일자 정보 유추가 어려우므로 캐싱 적용이 어려울 것으로 보입니다.  <br> 

**추후 시도해 볼 방향 :**  <br>
코치님의 조언에 따라 좌석 테이블에서 상태라는 조건을 제거할 예정입니다. <br> 
그렇게 되면 좌석 정보 자체도 캐싱 처리가 가능할 것으로 보입니다. <br> 

**<질문사항>**  <br> 
${\textsf{\color{magenta}콘서트 예약 일자도 캐싱으로 고정해놓고, 특정 일자 선택시 좌석 없으면 좌석없음" 이라고 하면 어떨까요?}}$ <br> 
${\textsf{\color{magenta}이 경우에는 예약 일자도 캐싱이 가능할 것 같다고 생각합니다.}}$ <br> 

<br><br>

## Step14. 대기열을 Redis 로 리팩토링 <br> 

기존 DB 대기열을 Redis로 이관하였습니다. <br><br>
![image](https://github.com/user-attachments/assets/d6cd8873-4d95-4ecb-97f3-f80f1af0cf6e)

### 리팩토링 설계 결과 <br> 

1. 50명 pool에 대해 제한을 없앴습니다.  <br>
2. DB의 큐 테이블을 삭제하고 redis 상에서 대기열 정보를 관리합니다. <br> 
3. 토큰 검증 관련 로직을 단순화 했습니다. <br> 
   -기존 : 토큰 유무 조회 -> 토큰 DB 조회 -> 토큰 상태값 조회 -> 상태에 따른 처리 (active 이면 진입 , wait이면 대기순서 반환 , expired면 만료 알림)  <br> 
   -변경 : 토큰 유무 조회 -> 토큰 Active 조회 or 토큰 Waiting 조회 -> 없으면 만료 처리 <br>
<br><br> 

### 고민했던 내용 <br> 
**token이 activeQueue로 전환될 때, TTL을 어떻게 줄 것인가?** <br> <br>
(1) 시도-1 ) redis레벨에서 TTL을 준다. (X) 전체가 아닌 각각의 토큰에 대해 10분 대기가 필요함 <br>  <br>
(2) 시도-2 ) 토큰을 생성하는 시점에 이미 날짜 정보를 붙여줌 (토큰:날짜)   (X) active token이 되는 순간부터 10분을 고려해야 하므로 실패<br> <br>
(3) 시도-3 ) 토큰이 active로 전환되는 시점에 (토큰:날짜) 처리를 함 ex) tokentoken:20240801121212 <br>  <br>
   => 하지만 사용자는 (토큰)만 가지고 있음 ex) tokentoken <br>  <br>
   => String의 contains 메서드와 시간비교 기능을 활용해 해결 (O)  <br>  <br>
![image](https://github.com/user-attachments/assets/703d86f4-3df3-45c0-8298-6a9ea9579310)